### PR TITLE
Added pyshark version for Python2 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pycrypto
 gevent
-pyshark
+pyshark==0.3.8
 prettytable
 sphinx_rtd_theme


### PR DESCRIPTION
Fix pyshark version to 0.3.8, the last version supported under Python 2.7:

https://github.com/KimiNewt/pyshark/blob/master/README.md
Python2 deprecation - This package no longer supports Python2. If you wish to still use it in Python2, you can:
•Use version 0.3.8