### PR TITLE
Update requirements.txt - latest pyshark no longer supports python2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pycrypto
 gevent
-pyshark
+pyshark==0.3.8
 prettytable
 sphinx_rtd_theme
 scapy


### PR DESCRIPTION
Installing the existing `requirements.txt` will pull the latest version of pyshark. After install and running the user will get an error telling them Pyshark requiers Python >= 3.5 and to install version 0.3.8 if they need to use Python2. This fixes that issue.